### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/marcschaeferger/newt/security/code-scanning/2](https://github.com/marcschaeferger/newt/security/code-scanning/2)

To address the issue, we should explicitly set the `permissions:` block in the workflow to limit the default token scope to only those permissions actually needed. As this workflow runs tests/builds but does not perform actions like publishing or modifying the repository, `contents: read` is sufficient. This can be set either at the workflow root (to affect all jobs, which is clearest and least error-prone here) or at the job level. We will add the following near the top, after the `name:` declaration and before the `on:` block to apply to the whole workflow:

```yaml
permissions:
  contents: read
```

No other changes or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
